### PR TITLE
msm7x27a-common: update overlays

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -177,6 +177,13 @@
         <item>0</item>
         <item>0</item>
     </integer-array>
+    
+    <integer name="config_buttonBrightnessSettingDefault">50</integer>
+    <integer name="config_keyboardBrightnessSettingDefault">0</integer>
+    <bool name="config_deviceHasVariableButtonBrightness">true</bool>
+    
+    <!-- Device supports LED flashlight -->
+    <bool name="config_enableTorch">true</bool>
 
     <!-- Hardware 'face' keys present on the device, stored as a bit field.
          This integer should equal the sum of the corresponding value for each


### PR DESCRIPTION
add torch config (needed to correctly show torch tile in quick settings)

add button brightness configs (it will show an extra menu in settings to change button brightness level, default value 50, like on Huawei stock ROM)
